### PR TITLE
refactor(strategy)!: Change function names for HashMap strategies

### DIFF
--- a/crates/conflate/src/hashmap.rs
+++ b/crates/conflate/src/hashmap.rs
@@ -8,24 +8,27 @@
 use std::collections::HashMap;
 use std::hash::Hash;
 
-/// On conflict, overwrite elements of `left` with `right`.
+/// Append values, on conflict, overwrite elements of `left` with `right`.
 ///
 /// In other words, this gives precedence to `right`.
-pub fn overwrite<K: Eq + Hash, V>(left: &mut HashMap<K, V>, right: HashMap<K, V>) {
+pub fn append_or_overwrite<K: Eq + Hash, V>(left: &mut HashMap<K, V>, right: HashMap<K, V>) {
     left.extend(right)
 }
 
-/// On conflict, ignore elements from `right`.
+/// Append values, on conflict, ignore elements from `right`.
 ///
 /// In other words, this gives precedence to `left`.
-pub fn ignore<K: Eq + Hash, V>(left: &mut HashMap<K, V>, right: HashMap<K, V>) {
+pub fn append_or_ignore<K: Eq + Hash, V>(left: &mut HashMap<K, V>, right: HashMap<K, V>) {
     for (k, v) in right {
         left.entry(k).or_insert(v);
     }
 }
 
-/// On conflict, recursively merge the elements.
-pub fn recurse<K: Eq + Hash, V: crate::Merge>(left: &mut HashMap<K, V>, right: HashMap<K, V>) {
+/// Append values, on conflict, recursively merge the elements.
+pub fn append_or_recurse<K: Eq + Hash, V: crate::Merge>(
+    left: &mut HashMap<K, V>,
+    right: HashMap<K, V>,
+) {
     use std::collections::hash_map::Entry;
 
     for (k, v) in right {

--- a/crates/conflate/tests/strategies.rs
+++ b/crates/conflate/tests/strategies.rs
@@ -172,7 +172,7 @@ mod hashmap {
     #[test]
     fn test_overwrite() {
         #[derive(Debug, Merge, PartialEq)]
-        struct S(#[merge(strategy = conflate::hashmap::overwrite)] HashMap<u8, u8>);
+        struct S(#[merge(strategy = conflate::hashmap::append_or_overwrite)] HashMap<u8, u8>);
 
         test(S(map! {1 => 2}), S(map! {1 => 1}), S(map! {1 => 2}));
         test(S(map! {1 => 1}), S(map! {1 => 2}), S(map! {1 => 1}));
@@ -182,7 +182,7 @@ mod hashmap {
     #[test]
     fn test_ignore() {
         #[derive(Debug, Merge, PartialEq)]
-        struct S(#[merge(strategy = conflate::hashmap::ignore)] HashMap<u8, u8>);
+        struct S(#[merge(strategy = conflate::hashmap::append_or_ignore)] HashMap<u8, u8>);
 
         test(S(map! {1 => 1}), S(map! {1 => 1}), S(map! {1 => 2}));
         test(S(map! {1 => 2}), S(map! {1 => 2}), S(map! {1 => 1}));
@@ -195,7 +195,7 @@ mod hashmap {
         struct N(#[merge(strategy = conflate::num::saturating_add)] u8);
 
         #[derive(Debug, Merge, PartialEq)]
-        struct S(#[merge(strategy = conflate::hashmap::recurse)] HashMap<u8, N>);
+        struct S(#[merge(strategy = conflate::hashmap::append_or_recurse)] HashMap<u8, N>);
 
         test(
             S(map! {1 => N(3)}),

--- a/crates/conflate/tests/strategies.rs
+++ b/crates/conflate/tests/strategies.rs
@@ -170,7 +170,7 @@ mod hashmap {
     }
 
     #[test]
-    fn test_overwrite() {
+    fn test_append_or_overwrite() {
         #[derive(Debug, Merge, PartialEq)]
         struct S(#[merge(strategy = conflate::hashmap::append_or_overwrite)] HashMap<u8, u8>);
 
@@ -180,7 +180,7 @@ mod hashmap {
     }
 
     #[test]
-    fn test_ignore() {
+    fn test_append_or_ignore() {
         #[derive(Debug, Merge, PartialEq)]
         struct S(#[merge(strategy = conflate::hashmap::append_or_ignore)] HashMap<u8, u8>);
 
@@ -190,7 +190,7 @@ mod hashmap {
     }
 
     #[test]
-    fn test_recurse() {
+    fn test_append_or_recurse() {
         #[derive(Debug, Merge, PartialEq)]
         struct N(#[merge(strategy = conflate::num::saturating_add)] u8);
 


### PR DESCRIPTION
BREAKING CHANGE: The strategy names for `HashMap` were a bit unclear. They first append and then on conflict something happens. So we prefixed them with `append_or` to make sure, that people understand that they will always try to append first.

Based on #13 